### PR TITLE
Allow alpha blending

### DIFF
--- a/blender_plots/blender_utils.py
+++ b/blender_plots/blender_utils.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-import numpy as np
 
 import bpy
+import numpy as np
 
 
 @dataclass
@@ -180,11 +180,15 @@ def get_vertex_color_material():
     """Create a material that obtains its color from the marker_color attribute"""
     material = bpy.data.materials.new("color")
     material.use_nodes = True
+    bsdf = material.node_tree.nodes.get("Principled BSDF")
+
     color_node = material.node_tree.nodes.new("ShaderNodeAttribute")
     color_node.attribute_name = Constants.MARKER_COLOR
 
-    material.node_tree.links.new(color_node.outputs["Color"],
-                                 material.node_tree.nodes["Principled BSDF"].inputs["Base Color"])
+    material.node_tree.links.new(color_node.outputs["Color"], bsdf.inputs["Base Color"])
+    material.node_tree.links.new(color_node.outputs["Alpha"], bsdf.inputs["Alpha"])
+
+    material.blend_method = "BLEND"
     return material
 
 def add_mesh_color(mesh, color):


### PR DESCRIPTION
Thank you so much for this great library!

This PR enables the use of alpha blending by connecting the `Alpha` socket from the `marker_color` attribute to the `Alpha` socket of the `Principled BSDF`:

| Before | After
| :-: |  :-: |
| ![image][before_nodes] | ![image][after_nodes] |
| ![image][before] | ![image][after] |

Code to reproduce:
```python
import blender_plots as bplt
import numpy as np

xyz = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]])
color = np.c_[np.eye(3), np.linspace(0.1, 1, 3)]  # RGBA
bplt.Scatter(xyz, color=color, marker_type="spheres", radius=1)
```

[before_nodes]: https://github.com/Linusnie/blender-plots/assets/71815905/4cb314cc-0700-454a-8777-8d2c7ffce0a6
[after_nodes]: https://github.com/Linusnie/blender-plots/assets/71815905/18013667-0909-4b93-aaf2-dc6ca3f21eef
[before]: https://github.com/Linusnie/blender-plots/assets/71815905/60cbb99a-6b54-4b7d-851c-6ca02cb8e368
[after]: https://github.com/Linusnie/blender-plots/assets/71815905/fb038b0a-4e87-428e-9b3c-e7aebb00b579